### PR TITLE
fix the early_stop_solver module

### DIFF
--- a/src/early_stop_solver.py
+++ b/src/early_stop_solver.py
@@ -274,8 +274,8 @@ class EarlyStopInt(torch.nn.Module):
     """
     method = self.opt['method']
     assert method in ['rk4', 'dopri5'], "Only dopri5 and rk4 implemented with early stopping"
-    shapes, func, y0, t, rtol, atol, method, options = _check_inputs(func, y0, self.t, rtol, atol, method, options,
-                                                                     SOLVERS)
+    event_fn = self.opt["event_fn"]
+    shapes, func, y0, t, rtol, atol, method, options, event_fn, t_is_reversed = _check_inputs(func, y0, self.t, rtol, atol, method, options, event_fn, SOLVERS)
 
     self.solver = SOLVERS[method](func, y0, rtol=rtol, atol=atol, opt=self.opt, **options)
     if self.solver.data is None:

--- a/src/run_GNN.py
+++ b/src/run_GNN.py
@@ -248,6 +248,7 @@ if __name__ == '__main__':
   parser.add_argument("--max_test_steps", type=int, default=100,
                       help="Maximum number steps for the dopri5Early test integrator. "
                            "used if getting OOM errors at test time")
+  parser.add_argument("--event_fn", type=str, default=None, help='Define event function')
 
   # Attention args
   parser.add_argument('--leaky_relu_slope', type=float, default=0.2,


### PR DESCRIPTION
I updated the `early_stop_solver` module when we use the recent torchdiffeq package.